### PR TITLE
TID #002 REST-API: Added post request to feed cat now

### DIFF
--- a/catfeeder-machine/rest-api.go
+++ b/catfeeder-machine/rest-api.go
@@ -39,7 +39,7 @@ func CreateNewFeedTime(w http.ResponseWriter, r *http.Request) {
 /***
  * @brief:  Handle to feed the cat.
  ***/
-func CreateFeednow(w http.ResponseWriter, r *http.Request) {
+func CreateFeedNow(w http.ResponseWriter, r *http.Request) {
     fmt.Println("Place holder to feed cat now, will update once TID003 is complete")
 }
 
@@ -93,7 +93,7 @@ func HandleRequests() {
     myRouter := mux.NewRouter().StrictSlash(true)
     myRouter.HandleFunc("/", HomePage)
     myRouter.HandleFunc("/feedingTime", CreateNewFeedTime).Methods("POST")
-    myRouter.HandleFunc("/feedNow", CreateFeednow).Methods("POST")
+    myRouter.HandleFunc("/feedNow", CreateFeedNow).Methods("POST")
     myRouter.HandleFunc("/feedingTimes", ReturnAllFeedingTimes).Methods("GET")
     myRouter.HandleFunc("/feedingTime/{id}", ReturnSingleFeedingTime).Methods("GET")
     log.Fatal(http.ListenAndServe(":6969", myRouter))

--- a/catfeeder-machine/rest-api.go
+++ b/catfeeder-machine/rest-api.go
@@ -44,7 +44,7 @@ func CreateFeedNow(w http.ResponseWriter, r *http.Request) {
 }
 
 /**
- * @brief:  Handle for recieving a specific feeding time.
+ * @brief:  Handle for returning a specific feeding time.
  **/
 func ReturnSingleFeedingTime(w http.ResponseWriter, r *http.Request) {
     vars := mux.Vars(r)
@@ -64,7 +64,7 @@ func ReturnSingleFeedingTime(w http.ResponseWriter, r *http.Request) {
 }
 
 /**
- * @brief:  Handle for recieving all the feeding times.
+ * @brief:  Handle for returning all the feeding times.
  **/
 func ReturnAllFeedingTimes(w http.ResponseWriter, r *http.Request) {
     mut.Lock()
@@ -75,7 +75,7 @@ func ReturnAllFeedingTimes(w http.ResponseWriter, r *http.Request) {
 }
 
 /**
- * @brief:  Handle to recieving info on REST API.
+ * @brief:  Handle to returning info on REST API.
  **/
 func HomePage(w http.ResponseWriter, r *http.Request) {
     fmt.Fprintln(w, "Cat Feeding times")

--- a/catfeeder-machine/rest-api.go
+++ b/catfeeder-machine/rest-api.go
@@ -36,6 +36,13 @@ func CreateNewFeedTime(w http.ResponseWriter, r *http.Request) {
     PrintFeedingTimes(ft)
 }
 
+/***
+ * @brief:  Handle to feed the cat.
+ ***/
+func CreateFeednow(w http.ResponseWriter, r *http.Request) {
+    fmt.Println("Place holder to feed cat now, will update once TID003 is complete")
+}
+
 /**
  * @brief:  Handle for recieving a specific feeding time.
  **/
@@ -74,6 +81,7 @@ func HomePage(w http.ResponseWriter, r *http.Request) {
     fmt.Fprintln(w, "Cat Feeding times")
     fmt.Fprintln(w, "-----------------------")
     fmt.Fprintln(w, "Create new feeding times with '/feedingTime'")
+    fmt.Fprintln(w, "Create request to feed cat now with '/feedNow'")
     fmt.Fprintln(w, "Return all feeding time with '/feedingTimes'")
     fmt.Fprintln(w, "Return single feeding time with '/feedingTime/<ID>'")
 }
@@ -85,6 +93,7 @@ func HandleRequests() {
     myRouter := mux.NewRouter().StrictSlash(true)
     myRouter.HandleFunc("/", HomePage)
     myRouter.HandleFunc("/feedingTime", CreateNewFeedTime).Methods("POST")
+    myRouter.HandleFunc("/feedNow", CreateFeednow).Methods("POST")
     myRouter.HandleFunc("/feedingTimes", ReturnAllFeedingTimes).Methods("GET")
     myRouter.HandleFunc("/feedingTime/{id}", ReturnSingleFeedingTime).Methods("GET")
     log.Fatal(http.ListenAndServe(":6969", myRouter))


### PR DESCRIPTION
### Synopsis:
Send request to feed the cat now rather than wait for a specific time to feed the cat.

### Description:
Instead of your cat starving until it's time to be fed, send a request to feed the cat now. Added a new REST API called `/feedNow` which will turn activate the motor to feed the cat. Currently, the servo motor isn't completed yet so there is a place holder that says to update once TID #003 is complete.

TID #009 created to update this once ready

### Test:
This can be done with curl currently.

In one shell, run the cat-feeder, and in another shell run the curl command

cURL shell
 ```shell
curl -X POST http://localhost:6969/feedNow
```

Cat-feeder shell
```shell
Not time to feed cats
Place holder to feed cat now, will update once TID003 is complete
Not time to feed cats
```