### PR TITLE
TID #007 Logging: Create a logger for both the app and the machine

### DIFF
--- a/catfeeder-app/src/catfeeder/app.py
+++ b/catfeeder-app/src/catfeeder/app.py
@@ -1,13 +1,10 @@
 """
 An app to feed the cats
 """
-import errno
 import json
 import requests
-import os
 import toga
 import utils
-from requests.exceptions import ConnectionError
 from toga.style import Pack
 from toga.style.pack import COLUMN, ROW
 

--- a/catfeeder-app/src/catfeeder/app.py
+++ b/catfeeder-app/src/catfeeder/app.py
@@ -138,7 +138,7 @@ class CatFeeder(toga.App):
                 return
             if req.status_code != 200:
                 logger.error("Uh oh! Request unsuccessful: HTTP(" + str(req.status_code) + ")")
-                self.error_label.text = "Failed to recieve request: HTTP(" + str(req.status_code) + ")"
+                self.error_label.text = "Failed to receive request: HTTP(" + str(req.status_code) + ")"
                 return
 
         except OSError as err:
@@ -153,7 +153,7 @@ class CatFeeder(toga.App):
             feeding_times.append((resp[i]['hour'],resp[i]['minute']))
             time = utils.PrettyTime(feeding_times[len(feeding_times) - 1])
             self.time_table.data.insert(i, time)
-        logger.error("Recieved feeding times:" + str(feeding_times))
+        logger.info("Received feeding times:" + str(feeding_times))
         self.send_butt.enabled = True
         self.error_label.text = ""
 

--- a/catfeeder-app/src/catfeeder/app.py
+++ b/catfeeder-app/src/catfeeder/app.py
@@ -76,17 +76,17 @@ class CatFeeder(toga.App):
     ###
     def addTime(self, widget):
         if self.hour_input.value == "":
-            print("Hour time is missing")
+            self.error_label.text = "Missing time for hour"
             return
         if self.min_input.value == "":
-            print("Minute time is missing")
+            self.error_label.text = "Missing time for minute"
             return
 
         self.send_butt.enabled = True
         feeding_times.append((self.hour_input.value,self.min_input.value))
         time = utils.PrettyTime(feeding_times[len(feeding_times) - 1])
         self.time_table.data.insert(0, time)
-        logger.error("New Time: " + str(time))
+        logger.info("New Time: " + str(time))
         self.error_label.text = ""
 
     ###
@@ -102,7 +102,7 @@ class CatFeeder(toga.App):
     ###
     def sendFeedingTime(self, widget):
         if len(feeding_times) == 0:
-            print("No times given")
+            self.error_label.text = "No feeding times present"
             return
 
         send_feeding_times = []
@@ -121,12 +121,12 @@ class CatFeeder(toga.App):
                 data = str(json.dumps(send_feeding_times))
             )
         except OSError as err:
-            logger.error("OSError: Uh oh! Looks like you are in trouble..." + utils.StrError(err))
-            self.error_label.text = "Error on communicating with machine"
+            logger.error("Uh oh! Looks like trouble found you: error(" + utils.StrOSError(err) + ")")
+            self.error_label.text = "Error on communicating with machine: error(" + utils.StrOSError(err) + ")"
             return
 
         resp = req.text
-        logger.error("Sent feeding time:" + str(resp))
+        logger.info("Sent feeding time:" + str(resp))
         self.error_label.text = ""
 
     ###
@@ -136,17 +136,17 @@ class CatFeeder(toga.App):
         try:
             req = requests.get(url = RECIEVE_ALL_TIMES)
             if req == None:
-                logger.error("Uh oh! Things not looking good")
+                logger.error("Uh oh! Received invalid feeding times: Feeding-Time(" + req + ")")
                 self.error_label.text = "Received invalid feeding times:", req
                 return
             if req.status_code != 200:
-                logger.error("Uh oh! Not success:" + str(req.status_code))
-                self.error_label.text = "Failed to recieve request:" + str(req.status_code)
+                logger.error("Uh oh! Request unsuccessful: HTTP(" + str(req.status_code) + ")")
+                self.error_label.text = "Failed to recieve request: HTTP(" + str(req.status_code) + ")"
                 return
 
         except OSError as err:
-            logger.error("OSError: Uh oh! Looks like you are in trouble..." + utils.StrError(err))
-            self.error_label.text = "Error on communicating with machine"
+            logger.error("Uh oh! Looks like trouble found you: error(" + utils.StrOSError(err) + ")")
+            self.error_label.text = "Error on communicating with machine: error(" + utils.StrOSError(err) + ")"
             return
 
         feeding_times = []

--- a/catfeeder-app/utils.py
+++ b/catfeeder-app/utils.py
@@ -19,7 +19,7 @@ def Applogger(name):
     return logger
 
 ###
-# @brief:   Turn the feeding time input to the time formate
+# @brief:   Turn the feeding time input to the time format
 #
 # @arg:     feeding_time - Array holding the hour and minute
 #
@@ -36,7 +36,7 @@ def PrettyTime(feeding_times):
 #
 # @arg:     err - OSError from try-except
 #
-# @return:  String formated error message
+# @return:  String formatted error message
 ###
 def StrOSError(err):
     return str(err.args[0].reason)[str(err.args[0].reason).find(":") + 2:]

--- a/catfeeder-app/utils.py
+++ b/catfeeder-app/utils.py
@@ -1,0 +1,21 @@
+import logging
+
+def Applogger(name):
+    logging.basicConfig(level=logging.WARNING,
+                        filename='/tmp/cat-feeder.log',
+                        format='%(asctime)s %(name)s - %(message)s',
+                        datefmt='%Y/%m/%d %H:%M:%S'
+                       )
+
+    logger = logging.getLogger(name)
+
+    return logger
+
+def PrettyTime(feeding_times):
+    hour = feeding_times[0]
+    minute = feeding_times[1]
+
+    return str(hour) + ":" + (str(minute) if int(minute) > 9 else "0" + str(minute))
+
+def StrError(err):
+    return str(err.args[0].reason)[str(err.args[0].reason).find(":") + 2:]

--- a/catfeeder-app/utils.py
+++ b/catfeeder-app/utils.py
@@ -1,7 +1,14 @@
 import logging
 
+###
+# @brief:   Create new logging object with the identity of `name`
+#
+# @arg:     name - The name to give the identity of the log
+#
+# @return:  Logger object
+###
 def Applogger(name):
-    logging.basicConfig(level=logging.WARNING,
+    logging.basicConfig(level=logging.INFO,
                         filename='/tmp/cat-feeder.log',
                         format='%(asctime)s %(name)s - %(message)s',
                         datefmt='%Y/%m/%d %H:%M:%S'
@@ -11,11 +18,25 @@ def Applogger(name):
 
     return logger
 
+###
+# @brief:   Turn the feeding time input to the time formate
+#
+# @arg:     feeding_time - Array holding the hour and minute
+#
+# @return:  String formated time
+###
 def PrettyTime(feeding_times):
     hour = feeding_times[0]
     minute = feeding_times[1]
 
     return str(hour) + ":" + (str(minute) if int(minute) > 9 else "0" + str(minute))
 
-def StrError(err):
+###
+# @brief:   Parse the OS error to return the error message
+#
+# @arg:     err - OSError from try-except
+#
+# @return:  String formated error message
+###
+def StrOSError(err):
     return str(err.args[0].reason)[str(err.args[0].reason).find(":") + 2:]

--- a/catfeeder-machine/golog.go
+++ b/catfeeder-machine/golog.go
@@ -7,7 +7,7 @@ import (
     "time"
 )
 
-type Logger struct {
+type Golog struct {
     Lock        sync.Mutex
     Fpath       *os.File
     Prefix      string
@@ -22,7 +22,7 @@ const LogFilename string = "/tmp/cat-feeder.log"
  *
  * @return: nil on success, else error
  **/
-func LoggerInit() error {
+func InitGolog() error {
     finfo, err := os.Stat(LogFilename)
     if err == nil {
         path := strings.Split(LogFilename, finfo.Name())[0]
@@ -39,20 +39,20 @@ func LoggerInit() error {
 }
 
 /**
- * @brief:  Create a Logger with prefix and filepath
+ * @brief:  Create a Golog with prefix and filepath
  *
  * @arg:    prefix - String to prepend to the log message
  *
  * @return: New logger, nil if error
  **/
-func NewLogger(prefix string) *Logger {
+func OpenGolog(prefix string) *Golog {
     fpath, err := os.OpenFile(LogFilename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 
     if err != nil {
         return nil
     }
 
-    return &Logger{
+    return &Golog{
         Prefix: prefix,
         Fpath: fpath,
     }
@@ -69,10 +69,10 @@ func NewLogger(prefix string) *Logger {
  * @return: int - How many bytes were written
  *          error - Errors while writing
  **/
-func (l *Logger) Println(msg string) (int, error) {
-    l.Lock.Lock()
-    defer l.Lock.Unlock()
+func (gl *Golog) Println(msg string) (int, error) {
+    gl.Lock.Lock()
+    defer gl.Lock.Unlock()
 
-    output := []byte(time.Now().Format("2006/01/02 15:04:05") + " " + l.Prefix + " - " + msg + "\n")
-    return l.Fpath.Write(output)
+    output := []byte(time.Now().Format("2006/01/02 15:04:05") + " " + gl.Prefix + " - " + msg + "\n")
+    return gl.Fpath.Write(output)
 }

--- a/catfeeder-machine/golog.go
+++ b/catfeeder-machine/golog.go
@@ -17,8 +17,7 @@ const LogFilename string = "/tmp/cat-feeder.log"
 
 /**
  * @brief:  Checks to see if the log file is present from a previous
- *          execution. If true, roll over log with timestamp. Then
- *          open a new log file.
+ *          execution. If true, roll over log with timestamp.
  *
  * @return: nil on success, else error
  **/
@@ -39,7 +38,8 @@ func InitGolog() error {
 }
 
 /**
- * @brief:  Create a Golog with prefix and filepath
+ * @brief:  Opens and creates a log file. If no errors opening/creating,
+ *          then create a Golog with prefix and file pointer
  *
  * @arg:    prefix - String to prepend to the log message
  *

--- a/catfeeder-machine/logger.go
+++ b/catfeeder-machine/logger.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+    "os"
+    "strings"
+    "sync"
+    "time"
+)
+
+type Logger struct {
+    Lock        sync.Mutex
+    Fpath       *os.File
+    Prefix      string
+}
+
+const LogFilename string = "/tmp/cat-feeder.log"
+
+var Fpath *os.File
+
+/**
+ * @brief:  Checks to see if the log file is present from a previous
+ *          execution. If true, roll over log with timestamp. Then
+ *          open a new log file.
+ *
+ * @return: nil on success, else error
+ **/
+func LoggerInit() (err error) {
+    finfo, err := os.Stat(LogFilename)
+    if err == nil {
+        path := strings.Split(LogFilename, finfo.Name())[0]
+        err = os.Rename(
+            LogFilename,
+            path + time.Now().Format("20060102T150405") + "-" + finfo.Name(),
+        )
+        if err != nil {
+            return err
+        }
+    }
+
+    Fpath, err = os.Create(LogFilename)
+    return err
+}
+
+/**
+ * @brief:  Create a Logger with prefix and filepath
+ *
+ * @arg:    prefix - String to prepend to the log message
+ *
+ * @return: New logger, nil if error
+ **/
+func NewLogger(prefix string) *Logger {
+    return &Logger{
+        Prefix: prefix,
+        Fpath: Fpath,
+    }
+}
+
+/**
+ * @brief:  Write log message to the log file. Log message contains:
+ *          - Timestamp
+ *          - Prefix
+ *          - Message
+ *
+ * @arg:    msg - Message to write to log file
+ *
+ * @return: int - How many bytes were written
+ *          error - Errors while writing
+ **/
+func (l *Logger) Println(msg string) (int, error) {
+    l.Lock.Lock()
+    defer l.Lock.Unlock()
+    output := []byte(time.Now().Format("2006/01/02 15:04:05") + " " + l.Prefix + " - " + msg + "\n")
+    return l.Fpath.Write(output)
+}

--- a/catfeeder-machine/logger.go
+++ b/catfeeder-machine/logger.go
@@ -15,8 +15,6 @@ type Logger struct {
 
 const LogFilename string = "/tmp/cat-feeder.log"
 
-var Fpath *os.File
-
 /**
  * @brief:  Checks to see if the log file is present from a previous
  *          execution. If true, roll over log with timestamp. Then
@@ -24,7 +22,7 @@ var Fpath *os.File
  *
  * @return: nil on success, else error
  **/
-func LoggerInit() (err error) {
+func LoggerInit() error {
     finfo, err := os.Stat(LogFilename)
     if err == nil {
         path := strings.Split(LogFilename, finfo.Name())[0]
@@ -37,7 +35,6 @@ func LoggerInit() (err error) {
         }
     }
 
-    Fpath, err = os.Create(LogFilename)
     return err
 }
 
@@ -49,9 +46,15 @@ func LoggerInit() (err error) {
  * @return: New logger, nil if error
  **/
 func NewLogger(prefix string) *Logger {
+    fpath, err := os.OpenFile(LogFilename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+
+    if err != nil {
+        return nil
+    }
+
     return &Logger{
         Prefix: prefix,
-        Fpath: Fpath,
+        Fpath: fpath,
     }
 }
 
@@ -69,6 +72,7 @@ func NewLogger(prefix string) *Logger {
 func (l *Logger) Println(msg string) (int, error) {
     l.Lock.Lock()
     defer l.Lock.Unlock()
+
     output := []byte(time.Now().Format("2006/01/02 15:04:05") + " " + l.Prefix + " - " + msg + "\n")
     return l.Fpath.Write(output)
 }

--- a/catfeeder-machine/main.go
+++ b/catfeeder-machine/main.go
@@ -38,14 +38,14 @@ func TimeToFeedCat() bool {
 }
 
 func init() {
-    if err := LoggerInit(); err != nil {
+    if err := InitGolog(); err != nil {
         fmt.Println("Failed to initialize log rollover:", err)
     }
 }
 
 func main() {
     /* Open log file */
-    cat_log := NewLogger("cat-manager")
+    cat_log := OpenGolog("cat-manager")
 
     /* Run REST API */
     go HandleRequests()

--- a/catfeeder-machine/rest-api.go
+++ b/catfeeder-machine/rest-api.go
@@ -9,7 +9,7 @@ import (
     "github.com/gorilla/mux"
 )
 
-var rest_log *Logger
+var rest_log *Golog
 
 func FeedingTimeStr(feeding_times []FeedingTimes) string {
     ft_str := ""
@@ -83,7 +83,7 @@ func HomePage(w http.ResponseWriter, r *http.Request) {
  * @brief:  Handle to monitor all the CRUD methods.
  **/
 func HandleRequests() {
-    rest_log = NewLogger("rest-api")
+    rest_log = OpenGolog("rest-api")
 
     myRouter := mux.NewRouter().StrictSlash(true)
     myRouter.HandleFunc("/", HomePage)

--- a/catfeeder-machine/rest-api.go
+++ b/catfeeder-machine/rest-api.go
@@ -4,18 +4,23 @@ import (
     "fmt"
     "io/ioutil"
     "encoding/json"
-    "log"
     "net/http"
 
     "github.com/gorilla/mux"
 )
 
-func PrintFeedingTimes(feeding_times []FeedingTimes) {
+var rest_log *Logger
+
+func FeedingTimeStr(feeding_times []FeedingTimes) string {
+    ft_str := ""
+
     for _, ft := range feeding_times {
-        fmt.Printf("{ ID(%s) -- Hour(%d) -- Minute(%d) } ",
-            ft.ID, ft.Hour, ft.Minute)
+        ft_str += fmt.Sprintf(" { ID(%s) -- Hour(%d) -- Minute(%d) } ",
+            ft.ID, ft.Hour, ft.Minute,
+        )
     }
-    fmt.Println()
+
+    return ft_str
 }
 
 /**
@@ -32,8 +37,7 @@ func CreateNewFeedTime(w http.ResponseWriter, r *http.Request) {
     json.NewEncoder(w).Encode(feeding_times)
     mut.Unlock()
 
-    fmt.Print("Recieved feeding times: ")
-    PrintFeedingTimes(ft)
+    rest_log.Println("Recieved feeding times:" + FeedingTimeStr(ft))
 }
 
 /**
@@ -47,9 +51,7 @@ func ReturnSingleFeedingTime(w http.ResponseWriter, r *http.Request) {
     for _, ft := range feeding_times {
         if ft.ID == key {
             json.NewEncoder(w).Encode(ft)
-            fmt.Print("Sending feeding time: ")
-            feeding := []FeedingTimes{ft}
-            PrintFeedingTimes(feeding)
+            rest_log.Println("Sending feeding time:" + FeedingTimeStr([]FeedingTimes{ft}))
             break
         }
     }
@@ -62,8 +64,7 @@ func ReturnSingleFeedingTime(w http.ResponseWriter, r *http.Request) {
 func ReturnAllFeedingTimes(w http.ResponseWriter, r *http.Request) {
     mut.Lock()
     json.NewEncoder(w).Encode(feeding_times)
-    fmt.Print("Sending feeding times: ")
-    PrintFeedingTimes(feeding_times)
+    rest_log.Println("Sending feeding times:" + FeedingTimeStr(feeding_times))
     mut.Unlock()
 }
 
@@ -82,10 +83,14 @@ func HomePage(w http.ResponseWriter, r *http.Request) {
  * @brief:  Handle to monitor all the CRUD methods.
  **/
 func HandleRequests() {
+    rest_log = NewLogger("rest-api")
+
     myRouter := mux.NewRouter().StrictSlash(true)
     myRouter.HandleFunc("/", HomePage)
     myRouter.HandleFunc("/feedingTime", CreateNewFeedTime).Methods("POST")
     myRouter.HandleFunc("/feedingTimes", ReturnAllFeedingTimes).Methods("GET")
     myRouter.HandleFunc("/feedingTime/{id}", ReturnSingleFeedingTime).Methods("GET")
-    log.Fatal(http.ListenAndServe(":6969", myRouter))
+
+    rest_log.Println("Listening on 127.0.0.1:6969")
+    rest_log.Println(http.ListenAndServe(":6969", myRouter).Error())
 }

--- a/catfeeder-machine/rest-api.go
+++ b/catfeeder-machine/rest-api.go
@@ -37,7 +37,7 @@ func CreateNewFeedTime(w http.ResponseWriter, r *http.Request) {
     json.NewEncoder(w).Encode(feeding_times)
     mut.Unlock()
 
-    rest_log.Println("Recieved feeding times:" + FeedingTimeStr(ft))
+    rest_log.Println("Received feeding times:" + FeedingTimeStr(ft))
 }
 
 /**


### PR DESCRIPTION
### Synopsis:
Add the ability to log for both the app and machine.

### Description:
Both the app and machine should log their error/info messages. Both of them log to the same file under a specific identity, (app="cat-app", machine="cat-machine", rest-api="rest-api"). This will make it easier to find and save any issues that occur.

There is a rollover initialization that will take the existing log file and then add a timestamp to it before starting a new log file.

### Test:
* Logs being rolled over and creating a new log  file
![image](https://user-images.githubusercontent.com/32848239/91452875-ba587180-e844-11ea-8ee0-296c38a4d363.png)

* Logs being added
![image](https://user-images.githubusercontent.com/32848239/91507907-ad1aa180-e89b-11ea-98f4-c3834463fe36.png)


**NOTE:** Will add show more test when I get home
